### PR TITLE
Fix `membership` action

### DIFF
--- a/membership/action.yaml
+++ b/membership/action.yaml
@@ -16,12 +16,7 @@ runs:
     - id: membership-check
       shell: bash
       run: |-
-        output=$(gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}")
-        status=$?
-
-        echo "::debug::${output}"
-
-        if [[ ${status} -ne 0 ]] ; then
+        if ! gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}" ; then
           echo "::set-output name=check-result::false"
         else
           echo "::set-output name=check-result::true"


### PR DESCRIPTION
The exit code was not properly encapsulated causing downstream execution to halt. The console message was already printed to the console so logging again at `debug` was redundant, simplified.