### PR TITLE
Avoid deprecated `set-output` in `membership` action

### DIFF
--- a/membership/action.yaml
+++ b/membership/action.yaml
@@ -17,9 +17,9 @@ runs:
       shell: bash
       run: |-
         if ! gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}" ; then
-          echo "::set-output name=check-result::false"
+          echo "name=check-result::false" >> ${GITHUB_OUTPUT}
         else
-          echo "::set-output name=check-result::true"
+          echo "name=check-result::true" >> ${GITHUB_OUTPUT}
         fi
       env:
         GH_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Avoids [warning](https://github.com/hazelcast/hazelcast-python-client/actions/runs/13280122985):
> Check membership of given user
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/