### PR TITLE
Update `membership` action to support `hazelcast` username

### DIFF
--- a/membership/action.yaml
+++ b/membership/action.yaml
@@ -16,7 +16,7 @@ runs:
     - id: membership-check
       shell: bash
       run: |-
-        if [[ "${{ inputs.organization-name }}" == "${{ inputs.member-name }}" ]] || gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}"; then
+        if [[ "${{ inputs.organization-name }}" == "${{ inputs.member-name }}" ]] || gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}" ]]; then
           echo "check-result=true" >> ${GITHUB_OUTPUT}
         else
           echo "check-result=false" >> ${GITHUB_OUTPUT}

--- a/membership/action.yaml
+++ b/membership/action.yaml
@@ -16,10 +16,10 @@ runs:
     - id: membership-check
       shell: bash
       run: |-
-        if ! gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}" ; then
-          echo "::set-output name=check-result::false"
+        if [[ "${{ inputs.organization-name }}" == "${{ inputs.member-name }}" ]] || gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}"; then
+          echo "name=check-result::true" >> ${GITHUB_OUTPUT}
         else
-          echo "::set-output name=check-result::true"
+          echo "name=check-result::false" >> ${GITHUB_OUTPUT}
         fi
       env:
         GH_TOKEN: ${{ inputs.token }}

--- a/membership/action.yaml
+++ b/membership/action.yaml
@@ -17,9 +17,9 @@ runs:
       shell: bash
       run: |-
         if [[ "${{ inputs.organization-name }}" == "${{ inputs.member-name }}" ]] || gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}"; then
-          echo "name=check-result::true" >> ${GITHUB_OUTPUT}
+          echo "check-result=true" >> ${GITHUB_OUTPUT}
         else
-          echo "name=check-result::false" >> ${GITHUB_OUTPUT}
+          echo "check-result=false" >> ${GITHUB_OUTPUT}
         fi
       env:
         GH_TOKEN: ${{ inputs.token }}

--- a/membership/action.yaml
+++ b/membership/action.yaml
@@ -16,7 +16,7 @@ runs:
     - id: membership-check
       shell: bash
       run: |-
-        if [[ "${{ inputs.organization-name }}" == "${{ inputs.member-name }}" || gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}" ]]; then
+        if [[ "${{ inputs.organization-name }}" == "${{ inputs.member-name }}" ]] || gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}"; then
           echo "check-result=true" >> ${GITHUB_OUTPUT}
         else
           echo "check-result=false" >> ${GITHUB_OUTPUT}

--- a/membership/action.yaml
+++ b/membership/action.yaml
@@ -16,7 +16,7 @@ runs:
     - id: membership-check
       shell: bash
       run: |-
-        if [[ "${{ inputs.organization-name }}" == "${{ inputs.member-name }}" ]] || gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}" ]]; then
+        if [[ "${{ inputs.organization-name }}" == "${{ inputs.member-name }}" || gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}" ]]; then
           echo "check-result=true" >> ${GITHUB_OUTPUT}
         else
           echo "check-result=false" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
In GitHub, usernames and organisations are unique.

The `membership` action is often triggered with `github.event.pull_request.head.repo.owner.login` - so for a _non_-fork PR the value will be `hazelcast` (the owner of a repo). `hazelcast` _isn't_ a member of the `hazelcast` organisation - it _is_ the organisation - so the check should pass and the PR should run. Updated check to suit.
