### PR TITLE
Fix `membership` action

### DIFF
--- a/membership/action.yaml
+++ b/membership/action.yaml
@@ -17,9 +17,9 @@ runs:
       shell: bash
       run: |-
         if ! gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}" ; then
-          echo "name=check-result::false" >> ${GITHUB_OUTPUT}
+          echo "check-result=false" >> ${GITHUB_OUTPUT}
         else
-          echo "name=check-result::true" >> ${GITHUB_OUTPUT}
+          echo "check-result=true" >> ${GITHUB_OUTPUT}
         fi
       env:
         GH_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
The syntax used in the change for https://github.com/hazelcast/hazelcast-tpm/pull/68 was incorrect, causing [build failures](https://github.com/hazelcast/hazelcast-csharp-client/actions/runs/13409810395).