### PR TITLE
Update `membership` check implementation to avoid PAT requirement

### DIFF
--- a/membership/action.yaml
+++ b/membership/action.yaml
@@ -1,7 +1,5 @@
 name: Check membership
 inputs:
-  organization-name:
-    required: true
   member-name:
     required: true
   token:
@@ -16,7 +14,7 @@ runs:
     - id: membership-check
       shell: bash
       run: |-
-        if [[ "${{ inputs.organization-name }}" == "${{ inputs.member-name }}" ]] || gh api "orgs/${{ inputs.organization-name }}/members/${{ inputs.member-name }}"; then
+        if [[ "${GITHUB_REPOSITORY_OWNER}" == "${{ inputs.member-name }}" ]] || gh api "repos/${GITHUB_REPOSITORY}/collaborators/${{ inputs.member-name }}"; then
           echo "check-result=true" >> ${GITHUB_OUTPUT}
         else
           echo "check-result=false" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
The `membership` action is used as a guard - to validate a user is trusted for action execution.

It's implemented calling an [API that validates if a user is a member of an organisation](https://docs.github.com/en/rest/orgs/members?apiVersion=2026-03-10#check-organization-membership-for-a-user) that requires _organisation_ permissions, unavailable to the default `GITHUB_TOKEN` - hence when called, we have to supply a (secret, hardcoded) PAT with such permissions.

It would _preferable_ to avoid requiring such a PAT for a myriad of reasons (long-lived, excessive permissions etc).

We can use an [alternate API to check if a user is a collaborator of the _repository_](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2026-03-10#check-if-a-user-is-a-repository-collaborator). As this is repo (not org) scoped, we _can_ use the default `GITHUB_TOKEN`.

This is a subtly different check - membership vs collaborator - but gives additional benefits:
> The authenticated user must have push access to the repository to use this endpoint.

I.E. rather than checking if the user is a member of (say) the `hazelcast` org, instead we are checking if they have `push` access to the _specific repo_.

This means if the repo has a more restrictive permission scheme - or alternatively, named external collaborators - it's respected.
In most real-world cases, a user with `push` access will be able to execute arbitrary actions _somehow_ anyway (e.g. create a new `pull_request` action and raise a PR in the repo), so such a restriction is not exposing any new vectors.
It also avoids having to supply (and hardcode) the `organization-name` parameter.

As this drops a (required) parameter, [the callers](https://github.com/search?q=org%3Ahazelcast+hazelcast%2Fhazelcast-tpm%2Fmembership+NOT+is%3Aarchived&type=code) will need to be updated simultaneously.

For testing, [a dummy public repo was created with an excerpt from the `code-samples` PR builder](https://github.com/JackPGreen/membership-test/blob/main/.github/workflows/builder.yaml).
This repo uses the updated implementation and uses the default token.
Another user - with no write permissions - raised [a PR](https://github.com/JackPGreen/membership-test/pull/1) and the [action execution was rejected](https://github.com/JackPGreen/membership-test/actions/runs/23500706710/attempts/1).
The user was then granted write permissions, and when the action was re-executed - [execution was accepted](https://github.com/JackPGreen/membership-test/actions/runs/23500706710).