### PR TITLE
Partially revert `Update membership check implementation to avoid PAT requirement`

### DIFF
--- a/membership/action.yaml
+++ b/membership/action.yaml
@@ -1,8 +1,11 @@
 name: Check membership
+description: Checks the specified member is part of the organisation derived from the calling repo - i.e. if called from `octocat/Spoon-Knife` with user input `mona`, checks if `mona` is in the `octocat` org
 inputs:
   member-name:
+    description: Typically github.actor
     required: true
   token:
+    description: A PAT (i.e. non-default token) scoped with '"Members" organization permissions (read)'
     required: true
 outputs:
   check-result:
@@ -14,7 +17,8 @@ runs:
     - id: membership-check
       shell: bash
       run: |-
-        if [[ "${GITHUB_REPOSITORY_OWNER}" == "${{ inputs.member-name }}" ]] || gh api "repos/${GITHUB_REPOSITORY}/collaborators/${{ inputs.member-name }}"; then
+        # https://docs.github.com/en/rest/orgs/members#list-organization-members
+        if [[ "${GITHUB_REPOSITORY_OWNER}" == "${{ inputs.member-name }}" ]] || gh api "orgs/${GITHUB_REPOSITORY_OWNER}/members/${{ inputs.member-name }}"; then
           echo "check-result=true" >> ${GITHUB_OUTPUT}
         else
           echo "check-result=false" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
Partially reverts https://github.com/hazelcast/hazelcast-tpm/pull/71

Although the change was tested in a test repo and worked, when applied in a real repo it [failed](https://github.com/hazelcast/hazelcast-python-client/actions/runs/23809305607/job/69391573334#step:2:16), always returning a `404` - the response for "user not in org".

_I think_ the difference is in how the repos are permissioned:
- the test repo gave explicit permissions to the test user, hence the API query to resolve the relative repository permissions for the test user was possible with the default token
- the real repo gives permissions to a _group in the org_, hence resolving relative permissions _still_ required resolving the group membership for a user which is not possible for the default token.

As such, I've _partially_ reverted this change - specifically:
- API call used goes back to what it was previously
- `organization-name` parameter is still removed as the simpler to infer
- added better documentation.

[Example (successful) execution in a real repo](http://github.com/hazelcast/hazelcast-python-client/actions/runs/23844626220/job/69508734139).